### PR TITLE
Fix cleanup on Jenkins

### DIFF
--- a/harness/scripts/destroy.sh
+++ b/harness/scripts/destroy.sh
@@ -8,7 +8,11 @@ if [[ "$SYNC_STRATEGY" = "mutagen" ]]; then
 fi
 
 if [[ "$APP_DYNAMIC" = "no" ]]; then
-    run "docker images --filter=reference='${DOCKER_REPOSITORY}:${APP_VERSION}-*' -q | xargs --no-run-if-empty docker image rm --force"
+    DOCKER_IMAGE_REFERENCE="${DOCKER_REPOSITORY}:${APP_VERSION}-*"
+    if [[ "$DOCKER_REPOSITORY" =~ ':' ]]; then
+      DOCKER_IMAGE_REFERENCE="${DOCKER_REPOSITORY}${APP_VERSION}*"
+    fi
+    run "docker images --filter=reference='${DOCKER_IMAGE_REFERENCE}' -q | xargs --no-run-if-empty docker image rm --force"
 fi
 
 run rm -f .my127ws/.flag-built


### PR DESCRIPTION
We had a docker image being left around after cleanup due to setting the repository to have a prefix attached:
```bash
docker images --filter=reference='quay.io/organisation/repo:prefix-:aaf8dfc4af641adadadeefefeff343ae-*'
```